### PR TITLE
Print nice error message when clone fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+#Python compiled code
+*.pyc
+
 # C extensions
 *.so
 
@@ -101,6 +104,7 @@ ENV/
 # mypy
 .mypy_cache/
 
+/source/
 configs/
 gui/
 test-reports/

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,11 @@
 import os
 import sys
 import unittest
+import contextlib
+
 from xmlrunner import XMLTestRunner
 import argparse
+import git
 from wiki import Wiki
 
 from tests.page_tests import PageTests
@@ -49,21 +52,35 @@ def run_all_tests(single_file, remote):
 
     if remote:
         for wiki in [DEV_MANUAL, IBEX_MANUAL, USER_MANUAL]:
-            with wiki:
-                pages = wiki.get_pages()
-                wiki_dir = wiki.get_path()
-                print("Running spelling tests")
-                return_values.append(run_tests_on_pages(
-                    os.path.join(reports_path, wiki.name), pages, wiki_dir, test_class=PageTests))
+            try:
+                with wiki:
+                    pages = wiki.get_pages()
+                    wiki_dir = wiki.get_path()
+                    print("Running spelling tests on {}".format(wiki.name))
+                    return_values.append(run_tests_on_pages(
+                        os.path.join(reports_path, wiki.name), pages, wiki_dir, test_class=PageTests))
+                    print()
+            except git.GitCommandError as ex:
+                print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
+                print("Skipping tests\n")
+                return_values.append(1)
+                continue
 
         for wiki in [DEV_MANUAL, USER_MANUAL]:
-            with wiki:
-                pages = wiki.get_pages()
-                wiki_dir = wiki.get_path()
-                # Only do shadow replication tests in "remote" mode.
-                print("Running shadow replication tests")
-                return_values.append(run_tests_on_pages(
-                    os.path.join(reports_path, wiki.name), pages, wiki_dir, test_class=ShadowReplicationTests))
+            try:
+                with wiki:
+                    pages = wiki.get_pages()
+                    wiki_dir = wiki.get_path()
+                    # Only do shadow replication tests in "remote" mode.
+                    print("Running shadow replication tests on {}".format(wiki.name))
+                    return_values.append(run_tests_on_pages(
+                        os.path.join(reports_path, wiki.name), pages, wiki_dir, test_class=ShadowReplicationTests))
+                    print()
+            except git.GitCommandError as ex:
+                print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
+                print("Skipping tests\n")
+                return_values.append(1)
+                continue
     else:
         return_values.append(run_tests_on_pages(
                 os.path.join(reports_path, os.path.basename(single_file)), [single_file], os.path.dirname(single_file),

--- a/run_tests.py
+++ b/run_tests.py
@@ -61,7 +61,7 @@ def run_all_tests(single_file, remote):
             except git.GitCommandError as ex:
                 print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
                 print("Skipping tests\n")
-                return_values.append(1)
+                return_values.append(False)
                 continue
 
         for wiki in [DEV_MANUAL, USER_MANUAL]:
@@ -77,7 +77,7 @@ def run_all_tests(single_file, remote):
             except git.GitCommandError as ex:
                 print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
                 print("Skipping tests\n")
-                return_values.append(1)
+                return_values.append(False)
                 continue
     else:
         return_values.append(run_tests_on_pages(

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,6 @@
 import os
 import sys
 import unittest
-import contextlib
-
 from xmlrunner import XMLTestRunner
 import argparse
 import git

--- a/run_tests.py
+++ b/run_tests.py
@@ -61,7 +61,7 @@ def run_all_tests(single_file, remote):
             except git.GitCommandError as ex:
                 print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
                 print("Skipping tests\n")
-                return_values.append(1)
+                return_values.append(0)
                 continue
 
         for wiki in [DEV_MANUAL, USER_MANUAL]:
@@ -77,7 +77,7 @@ def run_all_tests(single_file, remote):
             except git.GitCommandError as ex:
                 print("FAILED to clone {}: {}".format(wiki.name, str(ex)))
                 print("Skipping tests\n")
-                return_values.append(1)
+                return_values.append(0)
                 continue
     else:
         return_values.append(run_tests_on_pages(


### PR DESCRIPTION
### Description of work
In older versions of Git for Windows, cloning a repo with files whose name included a colon would succeed with no warnings, but the problematic files would be missing and count as deleted. In more recent versions, cloning a repo fails with an error if any files contain characters not supported by Windows.

This change makes it much easier to detect if any files contain invalid characters, so I've updated Git to the latest version on all Windows Jenkins hosts. I've also wrapped the wiki clone code in `try/except` blocks to give a nice error message when cloning fails.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5127

### Acceptance criteria
- [x] If a page with a colon in its name is created on the [wiki](https://github.com/ISISComputingGroup/ibex_developers_manual), the wiki checker fails

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

