### PR TITLE
Whitelist GitHub links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 #Python compiled code
 *.pyc
+chardetect.exe
 
 # C extensions
 *.so

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -156,7 +156,8 @@ class PageTests(unittest.TestCase):
 
         def check_skip_conditions(url, filenames, folders):
             # Extra condition checks if it links to a file location on the wiki
-            return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders
+            is_github_link = get_url_basename(url) == "github.com"
+            return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders or is_github_link
 
         def try_to_connect(url, session):
             nonlocal wiki_name, page_name
@@ -230,6 +231,7 @@ class PageTests(unittest.TestCase):
             return url.split("/")[2]
 
         def check_link(lnk, sess, filenames, folders):
+
             if not check_skip_conditions(lnk, filenames, folders):
                 failure = try_to_connect(lnk, sess)
                 if failure:

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -156,6 +156,9 @@ class PageTests(unittest.TestCase):
 
         def check_skip_conditions(url, filenames, folders):
             # Extra condition checks if it links to a file location on the wiki
+            # Also White list github links from checking for the moment if they are valid as GitHub limits 
+            # calls to 300 an hour which is not enough, and it throws an HTTP 429 error code. Future ticket will 
+            # uses the Github API to circumvent this issue.
             is_github_link = get_url_basename(url) == "github.com"
             return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders or is_github_link
 


### PR DESCRIPTION
White list github links from checking if they are valid as Git Hub limits calls to 300 an hours, which is not enough, and it throws an HTTP 429 error code. I will make a ticket so that we change the test code so it uses the Github API to circumvent this issue.