### PR TITLE
Ticket5363: Check GitHub urls

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -6,15 +6,11 @@ import argparse
 import git
 from wiki import Wiki
 
-from tests.page_tests import PageTests
+from tests.page_tests import PageTests, DEV_MANUAL, IBEX_MANUAL, USER_MANUAL, TEST_WIKI
 from tests.shadow_mirroring_tests import ShadowReplicationTests
 from utils.ignored_words import IGNORED_ITEMS
 import utils.global_vars
 
-DEV_MANUAL = Wiki("ibex_developers_manual")
-IBEX_MANUAL = Wiki("IBEX")
-USER_MANUAL = Wiki("ibex_user_manual")
-TEST_WIKI = Wiki("ibex_wiki_checker")
 
 
 def run_tests_on_pages(reports_path, pages, wiki_dir, test_class):

--- a/run_tests.py
+++ b/run_tests.py
@@ -11,7 +11,6 @@ from utils.ignored_words import IGNORED_ITEMS
 import utils.global_vars
 
 
-
 def run_tests_on_pages(reports_path, pages, wiki_dir, test_class):
     suite = unittest.TestSuite()
     loader = unittest.TestLoader()

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,7 +4,6 @@ import unittest
 from xmlrunner import XMLTestRunner
 import argparse
 import git
-from wiki import Wiki
 
 from tests.page_tests import PageTests, DEV_MANUAL, IBEX_MANUAL, USER_MANUAL, TEST_WIKI
 from tests.shadow_mirroring_tests import ShadowReplicationTests

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -164,9 +164,6 @@ class PageTests(unittest.TestCase):
 
         def check_skip_conditions(url, filenames, folders):
             # Extra condition checks if it links to a file location on the wiki
-            # Also White list github links from checking for the moment if they are valid as GitHub limits 
-            # calls to 300 an hour which is not enough, and it throws an HTTP 429 error code. Future ticket will 
-            # uses the Github API to circumvent this issue.
             return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders
 
         def try_to_connect(url, session):

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -243,13 +243,13 @@ class PageTests(unittest.TestCase):
             else:
                 return url
 
-        def check_link(link, sess, filenames, folders):
+        def check_link(link, session, filenames, folders):
             if not check_skip_conditions(link, filenames, folders):
                 if get_url_basename(link) == "github.com" and any([f"{wiki.name}/wiki" in link for wiki in WIKI_INCLUDELIST]):
-                    #todo call check_if_link_to_wiki_page()
-                    print(link)
-                    return
-                failure = try_to_connect(link, sess)
+                    # Get the wiki page name and append .md to it to check if the file exists in the local wiki repo
+                    _page_file_name = f"{link.split('/')[-1]}.md"
+                    return check_if_link_to_wiki_page(_page_file_name, filenames, folders)
+                failure = try_to_connect(link, session)
                 if failure:
                     write_to_file(failure)
             elif check_if_link_to_wiki_page(link, filenames, folders):

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -10,6 +10,14 @@ import utils.global_vars
 from enchant.checker import SpellChecker
 from enchant.tokenize import URLFilter, EmailFilter, WikiWordFilter, MentionFilter
 
+from wiki import Wiki
+
+DEV_MANUAL = Wiki("ibex_developers_manual")
+IBEX_MANUAL = Wiki("IBEX")
+USER_MANUAL = Wiki("ibex_user_manual")
+TEST_WIKI = Wiki("ibex_wiki_checker")
+WIKI_WHITELIST = [USER_MANUAL, IBEX_MANUAL, DEV_MANUAL]
+
 
 def strip_between_tags(expression, text):
     if text is None:
@@ -159,8 +167,7 @@ class PageTests(unittest.TestCase):
             # Also White list github links from checking for the moment if they are valid as GitHub limits 
             # calls to 300 an hour which is not enough, and it throws an HTTP 429 error code. Future ticket will 
             # uses the Github API to circumvent this issue.
-            is_github_link = get_url_basename(url) == "github.com"
-            return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders or is_github_link
+            return short_check_skip_conditions(url, filenames) or url.split("/")[0] in folders
 
         def try_to_connect(url, session):
             nonlocal wiki_name, page_name
@@ -236,14 +243,16 @@ class PageTests(unittest.TestCase):
             else:
                 return url
 
-        def check_link(lnk, sess, filenames, folders):
-
-            if not check_skip_conditions(lnk, filenames, folders):
-                failure = try_to_connect(lnk, sess)
+        def check_link(link, sess, filenames, folders):
+            if not check_skip_conditions(link, filenames, folders):
+                if get_url_basename(link) == "github.com" and any([wiki in link for wiki in [f"{wiki.name}/wiki" for wiki in WIKI_WHITELIST]]):
+                    print(link)
+                    return
+                failure = try_to_connect(link, sess)
                 if failure:
                     write_to_file(failure)
-            elif check_if_link_to_wiki_page(lnk, filenames, folders):
-                return "Could not follow page link {}".format(lnk)
+            elif check_if_link_to_wiki_page(link, filenames, folders):
+                return "Could not follow page link {}".format(link)
 
         # Have to open as UTF-8. Opening as ascii causes some encoding errors.
         try:

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -16,7 +16,7 @@ DEV_MANUAL = Wiki("ibex_developers_manual")
 IBEX_MANUAL = Wiki("IBEX")
 USER_MANUAL = Wiki("ibex_user_manual")
 TEST_WIKI = Wiki("ibex_wiki_checker")
-WIKI_WHITELIST = [USER_MANUAL, IBEX_MANUAL, DEV_MANUAL]
+WIKI_INCLUDELIST = [USER_MANUAL, IBEX_MANUAL, DEV_MANUAL, TEST_WIKI]
 
 
 def strip_between_tags(expression, text):
@@ -245,7 +245,8 @@ class PageTests(unittest.TestCase):
 
         def check_link(link, sess, filenames, folders):
             if not check_skip_conditions(link, filenames, folders):
-                if get_url_basename(link) == "github.com" and any([wiki in link for wiki in [f"{wiki.name}/wiki" for wiki in WIKI_WHITELIST]]):
+                if get_url_basename(link) == "github.com" and any([f"{wiki.name}/wiki" in link for wiki in WIKI_INCLUDELIST]):
+                    #todo call check_if_link_to_wiki_page()
                     print(link)
                     return
                 failure = try_to_connect(link, sess)


### PR DESCRIPTION
Originally the solution for ticket [5363](https://github.com/ISISComputingGroup/IBEX/issues/5363)  was to use the Github API to resolve links on the wiki that directed to other wiki pages, however the API [cannot be used to do this](https://github.community/t/api-for-repositorys-wiki/902)

The workaround was unexcluding Github pages from the link checker, and add a conditional to check whether the Github links were to one of our Wikis. if this is the case, compare against the local cloned copies rather than trying to ping the Github URL (the same way relative wiki page links are handled). This should drastically limit the amount of calls to Github pages and therefore make it less likely for the tests to fail because of the limit.

For ticket ISISComputingGroup/IBEX#5363