### PR TITLE
Add issue checking workaround to avoid Github rate limits

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -13,6 +13,8 @@ from tests.shadow_mirroring_tests import ShadowReplicationTests
 from utils.ignored_words import IGNORED_ITEMS
 import utils.global_vars
 
+GITHUB_API_ISSUE_CALL = f"https://api.github.com/repos/ISISComputingGroup/IBEX/issues?per_page=1"
+
 
 def run_tests_on_pages(reports_path, pages, wiki_dir, highest_issue_num, test_class):
     suite = unittest.TestSuite()
@@ -50,7 +52,7 @@ def run_all_tests(single_file, remote):
     utils.global_vars.init()
 
     if remote:
-        top_issue_num = json.loads(requests.get("https://api.github.com/repos/ISISComputingGroup/IBEX/issues?per_page=1").content)[0]["number"]
+        top_issue_num = int(json.loads(requests.get(GITHUB_API_ISSUE_CALL).content)[0]["number"])
         for wiki in [DEV_MANUAL, IBEX_MANUAL, USER_MANUAL]:
             try:
                 with wiki:

--- a/run_tests.py
+++ b/run_tests.py
@@ -51,8 +51,8 @@ def run_all_tests(single_file, remote):
     #  initialise globals, currently just string of warnings
     utils.global_vars.init()
 
+    top_issue_num = int(json.loads(requests.get(GITHUB_API_ISSUE_CALL).content)[0]["number"])
     if remote:
-        top_issue_num = int(json.loads(requests.get(GITHUB_API_ISSUE_CALL).content)[0]["number"])
         for wiki in [DEV_MANUAL, IBEX_MANUAL, USER_MANUAL]:
             try:
                 with wiki:
@@ -85,8 +85,8 @@ def run_all_tests(single_file, remote):
                 continue
     else:
         return_values.append(run_tests_on_pages(
-                os.path.join(reports_path, os.path.basename(single_file)), [single_file], os.path.dirname(single_file),
-                test_class=PageTests))
+            os.path.join(reports_path, os.path.basename(single_file)), [single_file], os.path.dirname(single_file),
+            top_issue_num, test_class=PageTests))
 
     return all(value for value in return_values)
 

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -272,7 +272,7 @@ class PageTests(unittest.TestCase):
         wiki_name = self.wiki_dir.split("\\")[-1]
         page_name = self.page.split("\\")[-1]
         links = get_urls_from_text(text)
-        folders = os.listdir(self.wiki_dir)
+        folders = os.listdir(self.wiki_dir) if self.wiki_dir else []
         filenames = [os.path.splitext(os.path.basename(f))[0].lower() for f in self.all_pages]
         with requests.Session() as sess:
             # Some websites don't respond correctly with the default requests user agent, so the firefox user agent

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -248,7 +248,7 @@ class PageTests(unittest.TestCase):
                     if IBEX_ISSUES in link:
                         # The link is to an IBEX issue, so check if its number is less than the total number of issues
                         issue_num = link.split(IBEX_ISSUES, 1)[-1]
-                        if not issue_num < self.top_issue_num:
+                        if not issue_num <= self.top_issue_num:
                             return "Invalid IBEX issue number: {}".format(issue_num)
                         return
                     if any([f"{wiki.name}/wiki" in link for wiki in WIKI_INCLUDELIST]):

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -247,7 +247,7 @@ class PageTests(unittest.TestCase):
                 if get_url_basename(link) == "github.com":
                     if IBEX_ISSUES in link:
                         # The link is to an IBEX issue, so check if its number is less than the total number of issues
-                        issue_num = link.split(IBEX_ISSUES, 1)[-1]
+                        issue_num = int(re.search(r'\d+', link)[0])  # Get the issue number in the URL
                         if not issue_num <= self.top_issue_num:
                             return "Invalid IBEX issue number: {}".format(issue_num)
                         return


### PR DESCRIPTION
for ticket ISISComputingGroup/IBEX#5711

Adds a crude check that gets the highest number of all Github tickets in the IBEX repo, then checks links that reference IBEX issues and makes sure their number is less than or equal to the highest issue number. This is to avoid actually calling the link which ends up making the wiki checker hit the github API rate limit and therefore falling over. 

