### PR TITLE
Don't check dev wiki (checks are now in sphinx)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -10,7 +10,7 @@ import requests
 from xmlrunner import XMLTestRunner
 
 import utils.global_vars
-from tests.page_tests import DEV_MANUAL, IBEX_MANUAL, USER_MANUAL, PageTests
+from tests.page_tests import IBEX_MANUAL, USER_MANUAL, PageTests
 from tests.shadow_mirroring_tests import ShadowReplicationTests
 from utils.ignored_words import IGNORED_ITEMS
 
@@ -58,7 +58,7 @@ def run_all_tests(single_file, remote, folder):
 
     top_issue_num = int(json.loads(requests.get(GITHUB_API_ISSUE_CALL).content)[0]["number"])
     if remote:
-        for wiki in [DEV_MANUAL, IBEX_MANUAL, USER_MANUAL]:
+        for wiki in [IBEX_MANUAL, USER_MANUAL]:
             try:
                 with wiki:
                     pages = wiki.get_pages()
@@ -80,7 +80,7 @@ def run_all_tests(single_file, remote, folder):
                 return_values.append(0)
                 continue
         print(utils.global_vars.failed_url_string)
-        for wiki in [DEV_MANUAL, USER_MANUAL]:
+        for wiki in [USER_MANUAL]:
             try:
                 with wiki:
                     pages = wiki.get_pages()

--- a/tests/page_tests.py
+++ b/tests/page_tests.py
@@ -14,11 +14,10 @@ from wiki import Wiki
 
 IBEX_ISSUES = "IBEX/issues/"
 
-DEV_MANUAL = Wiki("ibex_developers_manual")
 IBEX_MANUAL = Wiki("IBEX")
 USER_MANUAL = Wiki("ibex_user_manual")
 TEST_WIKI = Wiki("ibex_wiki_checker")
-WIKI_INCLUDELIST = [USER_MANUAL, IBEX_MANUAL, DEV_MANUAL, TEST_WIKI]
+WIKI_INCLUDELIST = [USER_MANUAL, IBEX_MANUAL, TEST_WIKI]
 
 
 def strip_between_tags(expression, text, current_page):


### PR DESCRIPTION
Spelling & internal link checks have now been migrated to `sphinx`, and as the wiki content has moved this was no longer actually checking anything useful. _External_ link checks were being ignored by this jenkins job, but sphinx has an equivalent (`sphinx -b linkcheck`) which is on a branch, should we want to enable it.

Shadow replication has also been updated to no longer use gollum and is now just a straight replica of the built html (see https://shadow.nd.rl.ac.uk/ibex_developers_manual/ ) - so no longer need to check for gollum failing to render pages.